### PR TITLE
tools: Make populate_db generate data like a production realm.

### DIFF
--- a/tools/rebuild-test-database
+++ b/tools/rebuild-test-database
@@ -33,7 +33,7 @@ create_zulip_test
 # This next line can be simplified to "-n0" once we fix our app (and tests) with 0 messages.
 ./manage.py populate_db --test-suite -n30 --threads=1 \
     --max-topics=3 \
-    --huddles=0 --personals=0 --percent-huddles=0 --percent-personals=0
+    --huddles=0 --personals=0 --percent-huddles=0 --percent-personals=0 --percent-attachments=0
 
 ./manage.py dumpdata \
     zerver.UserProfile zerver.Stream zerver.Recipient \

--- a/zilencer/management/commands/populate_db.py
+++ b/zilencer/management/commands/populate_db.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 import random
+import tempfile
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Sequence, Tuple
@@ -10,6 +11,7 @@ import orjson
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.core.files.base import File
+from django.core.files.uploadedfile import UploadedFile
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandParser
 from django.core.validators import validate_email
@@ -43,6 +45,7 @@ from zerver.lib.server_initialization import create_internal_realm, create_users
 from zerver.lib.storage import static_path
 from zerver.lib.stream_color import STREAM_ASSIGNMENT_COLORS
 from zerver.lib.types import ProfileFieldData
+from zerver.lib.upload import upload_message_attachment_from_request
 from zerver.lib.users import add_service
 from zerver.lib.utils import generate_api_key
 from zerver.models import (
@@ -198,6 +201,18 @@ def create_alert_words(realm_id: int) -> None:
     AlertWord.objects.bulk_create(recs)
 
 
+def create_attachment(user: UserProfile) -> str:
+    attach_file = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
+    attach_file.write("temporary test attachment file")
+    attach_file.close()
+    file_size = os.stat(attach_file.name).st_size
+    locator: str
+    with open(attach_file.name, "rb") as fp:
+        locator = upload_message_attachment_from_request(UploadedFile(fp), user, file_size)
+    os.unlink(attach_file.name)
+    return locator
+
+
 class Command(BaseCommand):
     help = "Populate a test database"
 
@@ -267,6 +282,13 @@ class Command(BaseCommand):
             type=float,
             default=15,
             help="The percent of messages to be personals.",
+        )
+
+        parser.add_argument(
+            "--percent-attachments",
+            type=float,
+            default=15,
+            help="The percent of messages to have attachments.",
         )
 
         parser.add_argument(
@@ -1172,6 +1194,7 @@ def generate_and_send_messages(
     recipients: Dict[int, Tuple[int, int, Dict[str, Any]]] = {}
     messages: List[Message] = []
     while num_messages < tot_messages:
+        has_attachment = False
         saved_data: Dict[str, Any] = {}
         message = Message(realm=realm)
         message.sending_client = get_client("populate_db")
@@ -1207,6 +1230,9 @@ def generate_and_send_messages(
             message_type = Recipient.STREAM
             message.recipient = get_recipient_by_id(random.choice(recipient_streams))
 
+        if randkey <= (random_max * options["percent_attachments"] / 100.0):
+            has_attachment = True
+
         if message_type == Recipient.DIRECT_MESSAGE_GROUP:
             sender_id = random.choice(huddle_members[message.recipient.id])
             message.sender = get_user_profile_by_id(sender_id)
@@ -1227,6 +1253,10 @@ def generate_and_send_messages(
         message.date_sent = choose_date_sent(
             num_messages, tot_messages, options["oldest_message_days"], options["threads"]
         )
+        if has_attachment:
+            locator = create_attachment(message.sender)
+            message.content += f"\n[attachment.txt]({locator})"
+
         messages.append(message)
 
         recipients[num_messages] = (message_type, message.recipient.id, saved_data)


### PR DESCRIPTION
Add attachment to a portion of messages.

Fix issue #14491

<!-- Describe your pull request here.-->

Fixes: <!-- Issue link, or clear description.-->

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
